### PR TITLE
dev to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - Dev
 
 env:
   DOTNET_VERSION: "9.x"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: Auth Server CI/CD
 
 on:
   push:
-    branches: ["main", "Dev"]
+    branches: ["main"]
 
 jobs:
   build-and-push:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,12 +1,14 @@
-services:
-  web-api:
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_HTTP_PORTS=8080
-      - ASPNETCORE_HTTPS_PORTS=8081
-    ports:
-      - "8080"
-      - "8081"
-    volumes:
-      - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
-      - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro
+# Override file for local development
+# For server deployment, use docker-compose.yml directly
+# services:
+#   auth-server:
+#     environment:
+#       - ASPNETCORE_ENVIRONMENT=Development
+#       - ASPNETCORE_HTTP_PORTS=8080
+#       - ASPNETCORE_HTTPS_PORTS=8081
+#     ports:
+#       - "8080"
+#       - "8081"
+#     volumes:
+#       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
+#       - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,48 +1,30 @@
 services:
-  web-api:
-    image: ${DOCKER_REGISTRY-}webapi
-    container_name: web-api
-    build:
-      context: .
-      dockerfile: src/Web.Api/Dockerfile
+  auth-server:
+    image: ghcr.io/dapplesoft-ad/auth-server:latest
+    container_name: auth-server
     ports:
-      - 5000:8080
-      - 5001:8081
+      - "8080:8080"
+      - "8081:8081"
     environment:
-      - ConnectionStrings__Database=Host=postgres;Port=5432;Database=clean-architecture;Username=postgres;Password=1234
+      - ASPNETCORE_ENVIRONMENT=Development # for Development
+      # - ASPNETCORE_ENVIRONMENT=Production # for Production
       - ASPNETCORE_URLS=http://+:8080;http://+:8081
-      - Jwt__Secret=YOUR_SECURE_GENERATED_SECRET
-    depends_on:
-      postgres:
-        condition: service_healthy
+      - ConnectionStrings__Database=Host=localhost;Port=5432;Database=authserver;Username=postgres;Password=pass1234
+    networks:
+      - auth-network
+    restart: unless-stopped
 
-  postgres:
-    image: postgres:18.1-alpine
-    container_name: postgres
-    environment:
-      - POSTGRES_DB=clean-architecture
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=1234
-    volumes:
-      # - ./.containers/db:/var/lib/postgresql/data
-      - postgres_data:/var/lib/postgresql/data
+  auth-server-frontend:
+    image: ghcr.io/dapplesoft-ad/auth-server-frontend:latest
+    container_name: auth-server-frontend
     ports:
-      - 5432:5432
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
-  seq:
-    image: datalust/seq:2024.3
-    container_name: seq
+      - "40003:4200"
     environment:
-      - ACCEPT_EULA=Y
-    ports:
-      - 8081:5341
+      - NODE_ENV=production
+    networks:
+      - auth-network
+    restart: unless-stopped
 
-
-
-volumes:
-  postgres_data: # Declares the named volume 'postgres_data'
+networks:
+  auth-network:
+    driver: bridge


### PR DESCRIPTION
This pull request updates the deployment and development configuration for the authentication server project. The main focus is on standardizing service names, updating Docker Compose files to match new naming conventions and deployment targets, and restricting CI/CD workflows to only trigger on the main branch. These changes aim to streamline deployment and improve clarity between development and production environments.

**Docker Compose configuration updates:**

* Renamed the main backend service from `web-api` to `auth-server`, updated its image to `ghcr.io/dapplesoft-ad/auth-server:latest`, and adjusted environment variables and ports for better clarity and production readiness. Also, removed the `postgres` and `seq` services and their associated volumes, and added a dedicated `auth-network` network.
* Added a new `auth-server-frontend` service using the image `ghcr.io/dapplesoft-ad/auth-server-frontend:latest`, exposing port `40003:4200` and connecting it to the new `auth-network`.
* Updated `docker-compose.override.yml` to comment out the previous `web-api` service configuration and add notes clarifying its use for local development versus server deployment.

**CI/CD workflow updates:**

* Modified both `.github/workflows/build.yml` and `.github/workflows/ci-cd.yml` to trigger only on pushes to the `main` branch, removing the `Dev` branch from the trigger list. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L8) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L5-R5)