### PR TITLE
✨ Add deployment step to CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -30,30 +30,30 @@ jobs:
           push: true
           tags: ghcr.io/dapplesoft-ad/auth-server:latest
 
-  # deploy-on-server:
-  #   runs-on: ubuntu-latest
-  #   needs: build-and-push
-  #   steps:
-  #     - name: Deploy on server via SSH
-  #       uses: appleboy/ssh-action@v1.2.0
-  #       with:
-  #         host: ${{ secrets.SERVER_IP }}
-  #         username: ${{ secrets.SERVER_USER }}
-  #         key: ${{ secrets.SERVER_SSH_KEY }}
-  #         script: |
-  #           echo "Starting deployment..."
-  #           # Login to GHCR on VPS using PAT
-  #           echo "${{ secrets.SERVER_GHCR_PAT }}" | docker login ghcr.io -u "dapplesoft-ad" --password-stdin
-  #           echo "Logged in to GitHub Container Registry"
-  #           # Navigate to Docker compose directory
-  #           cd /home/dapplesoft-ad/apps/docker-composes
-  #           # Pull latest image for the auth server service
-  #           docker compose -f auth-server.yml pull auth-server
-  #           echo "Pulled latest image"
-  #           # Recreate the container with the updated image
-  #           docker compose -f auth-server.yml up -d --force-recreate auth-server
-  #           echo "Recreated container with latest image"
-  #           # Clean unused images safely
-  #           docker image prune -f || true
-  #           echo "Cleaned unused Docker images"
-  #           echo "Deployment complete"
+  deploy-on-server:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: Deploy on server via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            echo "Starting deployment..."
+            # Login to GHCR on VPS using PAT
+            echo "${{ secrets.SERVER_GHCR_PAT }}" | docker login ghcr.io -u "dapplesoft-ad" --password-stdin
+            echo "Logged in to GitHub Container Registry"
+            # Navigate to Docker compose directory
+            cd /home/dapplesoft/apps/docker-compose
+            # Pull latest image for the auth server service
+            docker compose -f auth-server.yml pull auth-server
+            echo "Pulled latest image"
+            # Recreate the container with the updated image
+            docker compose -f auth-server.yml up -d --force-recreate auth-server
+            echo "Recreated container with latest image"
+            # Clean unused images safely
+            docker image prune -f || true
+            echo "Cleaned unused Docker images"
+            echo "Deployment complete"


### PR DESCRIPTION
This pull request re-enables and updates the `deploy-on-server` job in the GitHub Actions workflow, allowing for automated deployment of the `auth-server` to the production server after a successful build and push. The deployment script is now active and has been updated to use the correct deployment directory.

Deployment workflow improvements:

* Re-enabled the `deploy-on-server` job in `.github/workflows/ci-cd.yml`, so deployments are now automated after the build-and-push step.
* Updated the deployment script to use the new directory path (`/home/dapplesoft/apps/docker-compose`) for Docker Compose files, ensuring the deployment process targets the correct location on the server.